### PR TITLE
Ajuste dos scripts para que não haja valores fixos dentro do script python de regiao dos recursos

### DIFF
--- a/delete_ebs_noAttached.py
+++ b/delete_ebs_noAttached.py
@@ -1,14 +1,12 @@
-import boto3
-import csv
 import os
+import csv
 import json
-from logging import basicConfig, info, error, INFO
+import boto3
 from io import StringIO
 from datetime import datetime
+from logging import basicConfig, info, error, INFO
 
-# regions = ["us-east-1", "sa-east-1"]
-
-#Variaveis de ambiente
+#Variaveis de ambiente passadas através do AWS Lambda
 BUCKET_NAME = os.environ.get("TARGET_BUCKET_S3")
 SNS_TOPIC_ARN = os.environ.get("SNS_TOPIC_ARN")
 REGIONS = os.environ.get("TARGET_REGIONS", "[]")

--- a/delete_ebs_noAttached.py
+++ b/delete_ebs_noAttached.py
@@ -1,17 +1,58 @@
 import boto3
 import csv
-import botocore
+import os
+import json
+from logging import basicConfig, info, error, INFO
+from io import StringIO
+from datetime import datetime
 
-regions = ["us-east-1", "sa-east-1"]
+# regions = ["us-east-1", "sa-east-1"]
 
+#Variaveis de ambiente
+BUCKET_NAME = os.environ.get("TARGET_BUCKET_S3")
+SNS_TOPIC_ARN = os.environ.get("SNS_TOPIC_ARN")
+REGIONS = os.environ.get("TARGET_REGIONS", "[]")
 
+#Criando um logging para o código
+basicConfig(level=INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+def upload_file_to_s3(file_path, bucket_name, object_name) -> bool:
+    '''
+    Realiza o upload de um arquivo para um Bucket S3.
+
+    :param file_path: Caminho completo para o arquivo local a ser enviado.
+    :param bucket_name: Nome do bucket S3 de destino.
+    :param object_name: Nome do objeto S3 (caminho completo no bucket).
+                        Se não for fornecido, o nome base do file_path será usado.
+    :return: True se o upload for bem-sucedido, False caso contrário.
+    '''
+
+    client = boto3.client("s3")
+    
+    if not bucket_name:
+        error("O nome do bucket S3 não foi fornecido verificar as variaveis de ambiente.")
+        return False
+
+    try:
+        info(f"Realizando upload do arquivo {file_path} para o bucket S3 s3//{bucket_name}")
+        client.put_object(Bucket=bucket_name, Key=object_name, Body=file_path)
+        info(f"Upload do arquivo {file_path} concluído com sucesso.")
+        return True
+    
+    except Exception as e:
+        error(f"Ocorreu um erro inesperado durante o upload: {e}")
+        return False
+    
 def send_email(
     count_ebs_excluidos_por_regiao,
     count_ebs_nao_excluidos_por_regiao,
     ebs_nao_excluidos,
 ):
     # Publicar mensagem no tópico SNS
-    sns_topic_arn = "arn:aws:sns:us-east-1:266549158321:finops_ebs_unattached"
+    sns_topic_arn = SNS_TOPIC_ARN
+    if not sns_topic_arn:
+        error("O ARN do tópico SNS não foi fornecido verificar as variaveis de ambiente.")
+        return
     sns_client = boto3.client("sns")
 
     # Formatando a mensagem para incluir o número de EBS excluídos e não excluídos em cada região
@@ -42,10 +83,31 @@ def send_email(
     sns_client.publish(TopicArn=sns_topic_arn, Message=message, Subject=subject)
 
 
+def create_csv_file(dict_data):
+    '''
+    Cria um arquivo CSV a partir de um dicionário de dados.
+
+    :param dict_data: Dicionário contendo os dados a serem escritos no arquivo CSV.
+    '''
+
+    # Criar um objeto StringIO para armazenar os dados CSV em memória
+    output_file = StringIO()
+
+    header_list = list(dict_data[0].keys())
+
+    csv_writer = csv.DictWriter(output_file, fieldnames=header_list)
+    csv_writer.writeheader() #Cabeçalho do CSV
+    csv_writer.writerows(dict_data) #Escreve os dados no CSV
+
+    csv_file = output_file.getvalue() #Obtendo os dados do CSV
+    info(f"CSV criado com {len(dict_data)} registros")
+    output_file.close() 
+
+    return csv_file
+
+
 # funcao lambda principal
-
-
-def lambda_handler(event, context):
+def handler(event, context):
     count_ebs_excluidos_por_regiao = (
         []
     )  # lista para armazenar o número de EBS excluídos em cada região
@@ -53,6 +115,9 @@ def lambda_handler(event, context):
         []
     )  # lista para armazenar o número de EBS não excluídos em cada região
 
+    volumes_list = []
+    
+    regions = json.loads(REGIONS)
     for region in regions:
         print(f"#### {region} ####")
 
@@ -84,9 +149,20 @@ def lambda_handler(event, context):
                         ebs_nao_excluidos.append(volume["VolumeId"])
                         count_ebs_nao_excluidos += 1
                     else:
+                    #Inclusao dos ebs que vao ser excluidos em uma lista para posterior upload em bucket s3    
+                        volumes_list.append({
+                            "VolumeId":volume["VolumeId"],
+                            "VolumeType":volume["VolumeType"],
+                            "Region":volume["AvailabilityZone"],
+                            "SizeGb":volume["Size"],
+                            "State":volume["State"],
+                            "Iops":volume.get("Iops",'N/A'),
+                            "Tags":tags,
+                            })
+                        info(f'Volume {volume["VolumeId"]} incluso na listagem para exclusão')
+                        
                         # Se o volume não possuiu a tag 'inUse', pode ser excluído
-                        ## retirar comentario de delecao
-                        ec2.delete_volume(VolumeId=volume["VolumeId"])
+                        # ec2.delete_volume(VolumeId=volume["VolumeId"])
                         print(f'Volume {volume["VolumeId"]} excluído com sucesso')
                         ebs_excluidos.append(volume["VolumeId"])
                         count_ebs_excluidos += 1
@@ -110,7 +186,6 @@ def lambda_handler(event, context):
         count_ebs_excluidos_por_regiao.append((region, count_ebs_excluidos))
         count_ebs_nao_excluidos_por_regiao.append((region, count_ebs_nao_excluidos))
 
-    ## retirar comentario do envio da send_email
     # enviar um email com o número de EBS excluídos e não excluídos em cada região
     send_email(
         count_ebs_excluidos_por_regiao,
@@ -118,6 +193,35 @@ def lambda_handler(event, context):
         ebs_nao_excluidos,
     )
 
-#Upload de arquivo para bucet s3
-def upload_file_to_s3(file_path, bucket_name, object_name):
-    pass
+    # Criando arquivo CSV com os volumes que foram excluídos
+    csv_file = create_csv_file(volumes_list)
+    if not csv_file:    
+        error("Erro ao criar o arquivo CSV")
+        return {
+            'statusCode': 500,
+            'body': 'Erro ao criar o arquivo CSV'
+        }
+    
+    # Definindo o nome do arquivo CSV
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    csv_object_key = f"unattached_ebs_{timestamp}.csv"
+
+    if not BUCKET_NAME:
+            error("O nome do bucket S3 não foi fornecido verificar as variaveis de ambiente.")
+            return {
+                'statusCode': 500,
+                'body': 'O nome do bucket S3 não foi fornecido verificar as variaveis de ambiente.'
+            }
+        
+    if upload_file_to_s3(csv_file, BUCKET_NAME, csv_object_key):
+        info(f"Arquivo CSV {csv_object_key} enviado para o bucket S3 {BUCKET_NAME} com sucesso.")
+        return {
+            'statusCode': 200,
+            'body': f'Arquivo CSV {csv_object_key} enviado para o bucket S3 {BUCKET_NAME}.'
+        }
+    else:
+        error(f"Falha ao enviar o arquivo CSV {csv_object_key} para o bucket S3 {BUCKET_NAME}.")
+        return {
+            'statusCode': 500,
+            'body': 'Falha ao enviar o arquivo CSV para o bucket S3.'
+        }

--- a/iac/modules/lambda_s3_sns/variables.tf
+++ b/iac/modules/lambda_s3_sns/variables.tf
@@ -19,7 +19,19 @@ variable "iam_role_name" {
   default     = "devfinops.tf.iam_role"
 }
 
+variable "iam_role_policy_name" {
+  type        = string
+  description = "Nome da policy IAM"
+  default     = "devfinops.tf.iam_role_policy"
+}
+
 ## Informações da Lambda ##
+variable "regions"{
+  type        = list(string)
+  description = "Regiões onde a lambda precisa verificar EBS não anexados"
+  default     = ["us-east-1", "sa-east-1"] 
+}
+
 variable "lambda_name" {
   type        = string
   description = "Nome da função Lambda"


### PR DESCRIPTION
Script python agora recupera os valores de regiao dos ebs atraves da passagem de informação via variavel de ambiente no processo de deploy feito via terrafom.
Modulo Terraform utilizando regiao como padrão us-east-1 e sa-east-1. 